### PR TITLE
Updates colors to match upstream

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -10,12 +10,11 @@ const colors = {
   threePO: '#e5cd52',
   r2: '#4fb4d8',
   luke: '#ef7c2a',
-  falcon: {
-    white: '#ececec',
-    silver: '#e0e0e0',
-    grey: '#636363',
-    black: '#212121'
-  }
+  veryLightGrey: '#cbcdd2',
+  lightGrey: '#848794',
+  grey: '#686b78',
+  darkGrey: '#45474f',
+  veryDarkGrey: '#1c1d21'
 }
 
 module.exports = config => {
@@ -23,31 +22,31 @@ module.exports = config => {
   const tabActiveMarker = themeSettings.tabActiveMarker || '►'
   const backgroundColor = `rgba(15, 15, 15, ${themeSettings.opacity || 0.9})`
   const styleColor = themeSettings.style === 'falcon'
-    ? colors.falcon.silver
+    ? colors.lightGrey
     : colors[themeSettings.style || 'luke']
 
   return {
     backgroundColor,
-    foregroundColor: colors.falcon.white,
-    borderColor: colors.falcon.grey,
+    foregroundColor: colors.veryLightGrey,
+    borderColor: colors.grey,
     cursorColor: styleColor,
     colors: {
-      black: colors.falcon.black,
+      black: colors.veryDarkGrey,
       red: colors.vader,
       green: colors.yoda,
       yellow: colors.threePO,
       blue: colors.r2,
       magenta: colors.luke,
       cyan: colors.r2,
-      white: colors.falcon.white,
-      lightBlack: colors.falcon.grey,
+      white: colors.veryLightGrey,
+      lightBlack: colors.grey,
       lightRed: colors.vader,
       lightGreen: colors.yoda,
       lightYellow: colors.threePO,
       lightBlue: colors.r2,
       lightMagenta: colors.luke,
       lightCyan: colors.r2,
-      lightWhite: colors.falcon.white
+      lightWhite: colors.veryLightGrey
     },
     termCSS: `
       ${config.termCSS || ''}
@@ -61,14 +60,14 @@ module.exports = config => {
     css: `
       ${config.css || ''}
       .tab_tab:not(.tab_active) {
-        color: ${colors.falcon.silver};
+        color: ${colors.lightGrey};
       }
       .tab_textActive .tab_textInner::before {
         color: ${styleColor};
         content: "${tabActiveMarker} ";
       }
       .splitpane_divider {
-        background-color: ${colors.falcon.grey} !important;
+        background-color: ${colors.grey} !important;
       }
     `
   }


### PR DESCRIPTION
Makes the colors match the source as defined by here: https://github.com/JesseLeite/an-old-hope-syntax-atom/blob/master/styles/colors.less

Hi there! Not sure if this plugin is inspired by or supposed to match the original source. If it maps 1:1 then this PR is intending to sync the colors as specified by the original atom syntax's colors.