### PR TITLE
Allows empty string as a tabActiveMarker

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -20,7 +20,9 @@ const colors = {
 
 module.exports = config => {
   const themeSettings = config.themeSettings || {}
-  const tabActiveMarker = typeof themeSettings.tabActiveMarker === 'string' ? themeSettings.tabActiveMarker : '►'
+  const tabActiveMarker = typeof themeSettings.tabActiveMarker === 'string' 
+    ? themeSettings.tabActiveMarker 
+    : '►'
   const backgroundColor = `rgba(15, 15, 15, ${themeSettings.opacity || 0.9})`
   const styleColor = themeSettings.style === 'falcon'
     ? colors.falcon.silver

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -20,7 +20,7 @@ const colors = {
 
 module.exports = config => {
   const themeSettings = config.themeSettings || {}
-  const tabActiveMarker = themeSettings.tabActiveMarker || '►'
+  const tabActiveMarker = typeof themeSettings.tabActiveMarker === 'string' ? themeSettings.tabActiveMarker : '►'
   const backgroundColor = `rgba(15, 15, 15, ${themeSettings.opacity || 0.9})`
   const styleColor = themeSettings.style === 'falcon'
     ? colors.falcon.silver


### PR DESCRIPTION
This relaxes the rules on which tab marker can be used by checking for a string value instead of testing whether it's falsy. The tabActiveMarker can now be cleared as a result.